### PR TITLE
Add support of TLS connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -272,7 +272,7 @@ func BlockingChan(blockingChan chan amqp.Blocking) ClientOpt {
 	}
 }
 
-// ErrorsChan is a functional option, used to setup TLS configuration
+// TLS is a functional option, used to setup TLS configuration
 func TLS(tls *tls.Config) ClientOpt {
 	return func(c *Client) {
 		c.tlsConf = tls

--- a/client.go
+++ b/client.go
@@ -118,7 +118,12 @@ func (c *Client) Loop() bool {
 		time.Sleep(c.bo.Backoff(int(c.attempt)))
 		atomic.AddInt32(&c.attempt, 1)
 	}
-	
+
+	// set default Heartbeat to 10 seconds like in original amqp.Dial
+	if c.config.Heartbeat == 0 {
+		c.config.Heartbeat = 10 * time.Second
+	}
+
 	conn, err = amqp.DialConfig(c.addr, c.config)
 
 	if c.reportErr(err) {

--- a/client.go
+++ b/client.go
@@ -118,12 +118,7 @@ func (c *Client) Loop() bool {
 		time.Sleep(c.bo.Backoff(int(c.attempt)))
 		atomic.AddInt32(&c.attempt, 1)
 	}
-
-	if c.config == nil {
-		c.config = amqp.Config{
-			Heartbeat: 10 * time.Second,
-		}
-	}
+	
 	conn, err = amqp.DialConfig(c.addr, c.config)
 
 	if c.reportErr(err) {


### PR DESCRIPTION
Just little change about support of TLS connections which sometimes useful.
Here is example of using with TLS:
```
amqp_url := "amqps://guest:guest@127.0.0.1:5671/"
cert, err := tls.LoadX509KeyPair("cert.pem", "key.pem")
tls_config := tls.Config{
			Certificates: []tls.Certificate{cert},
			InsecureSkipVerify: true}
cli := cony.NewClient(
		cony.URL(amqp_url),
		cony.Backoff(cony.DefaultBackoff),
		cony.TLS(&tls_config),
	)
```